### PR TITLE
Fixed a build error

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -6,7 +6,7 @@ dnl Define HAVE_STRUCT_UTIMBUF if `struct utimbuf' is declared --
 dnl usually in <utime.h>.
 dnl Some systems have utime.h but don't declare the struct anywhere.
 
-AC_DEFUN(jm_CHECK_TYPE_STRUCT_UTIMBUF,
+AC_DEFUN([jm_CHECK_TYPE_STRUCT_UTIMBUF],
 [
   AC_CHECK_HEADERS(utime.h)
   AC_REQUIRE([AC_HEADER_TIME])

--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,7 @@ dnl here (BUT NOT the files in debian/)
 AM_INIT_AUTOMAKE(evrouter, $PACKAGE_VERSION)
 
 dnl create a config.h file (Automake will add -DHAVE_CONFIG_H)
-AM_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS([config.h])
 
 AC_SUBST(VERSION)
 


### PR DESCRIPTION
Updated an obsolete macro.

```
configure.ac:49: error: 'AM_CONFIG_HEADER': this macro is obsolete.
    You should use the 'AC_CONFIG_HEADERS' macro instead.
```

Take care,
--Chris
